### PR TITLE
Create issue_template.md

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,17 @@
+<!-- If you are interested in proposing a talk, please create an issue using the following format -->
+
+Name:
+
+Twitter Handle:
+
+GitHub Username:
+
+Employer:
+
+Talk Length:
+
+---
+
+Title:
+
+Brief Description:


### PR DESCRIPTION
I figured this would be a quick way to enforce a standard template for talk issues. If there is a wanted issue template for non-talk issues, it is possible to have multiple issue templates that can be linked to with a query param in the README by following this:
https://help.github.com/articles/about-automation-for-issues-and-pull-requests-with-query-parameters/